### PR TITLE
Implementação do swagger documentação

### DIFF
--- a/BackEnd/GestaoDeClientes.API/Controllers/ClienteController.cs
+++ b/BackEnd/GestaoDeClientes.API/Controllers/ClienteController.cs
@@ -1,5 +1,7 @@
 ﻿using GestaoDeClientes.Application.Interfaces;
 using GestaoDeClientes.Domain.Model;
+
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 
@@ -16,13 +18,27 @@ namespace GestaoDeClientes.API.Controllers
             _client = client;
         }
 
+        /// <summary>
+        /// Endpoint responsável por consultar o cliente pelo id.
+        /// </summary>
+        /// <param name="id">Código de identificação</param>
+        /// <returns>Returna o resultado da operação com objeto preenchido.</returns>
+        [ProducesResponseType(typeof(Cliente), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         [HttpGet("{id:int}")]
         public async Task<ActionResult<Cliente>> Get(int id)
         {
             var result = await _client.GetByIdAsync(id);
             if (result is null)
             {
-                return NotFound();
+                return NotFound(new
+                {
+                    Instance = $"api/Clientes/{id}",
+                    status = 404,
+                    error = "Recurso não encontrado",
+                    message = "Ocorreu um erro ao tentar encontrar seu cliente.",
+                    Method = "Get",
+                });
             }
             return Ok(result);
         }

--- a/BackEnd/GestaoDeClientes.API/Extension/ServiceExtensions.cs
+++ b/BackEnd/GestaoDeClientes.API/Extension/ServiceExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace GestaoDeClientes.API.Extension
+{
+    public static class ServiceExtensions
+    {
+        public static void AddSwagger(this IServiceCollection services)
+        {
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1",
+                    new OpenApiInfo
+                    {
+                        Title = "GestaoDeClientes.API",
+
+                        Version = "v1",
+                        Contact = new OpenApiContact
+                        {
+                            Name = "Gestão de clientes",
+                        },
+                        Description = "Uma API para gestão de clientes é um sistema que fornece endpoints para realizar operações" +
+                        " CRUD (Create, Read, Update, Delete) relacionadas aos clientes de uma empresa."
+                    });
+
+                var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+                c.IncludeXmlComments(xmlPath);
+            });
+        }
+
+        public static void UseSwaggerUI(this IApplicationBuilder app)
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("v1/swagger.json", "Gestão de clientes API");
+            });
+        }
+    }
+}

--- a/BackEnd/GestaoDeClientes.API/GestaoDeClientes.API.csproj
+++ b/BackEnd/GestaoDeClientes.API/GestaoDeClientes.API.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.15" />

--- a/BackEnd/GestaoDeClientes.API/Program.cs
+++ b/BackEnd/GestaoDeClientes.API/Program.cs
@@ -1,4 +1,5 @@
 
+using GestaoDeClientes.API.Extension;
 using GestaoDeClientes.Application.Interfaces;
 using GestaoDeClientes.Infrastructure.Data;
 using GestaoDeClientes.Infrastructure.Repositories;
@@ -14,6 +15,7 @@ namespace GestaoDeClientes.API
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
+            builder.Services.AddSwagger();
 
             // Add services to the container.
 
@@ -21,9 +23,11 @@ namespace GestaoDeClientes.API
             builder.Services.AddScoped<ICadastroCliente, CadastroCliente>();
 
             builder.Services.AddControllers();
+            builder.Services.AddEndpointsApiExplorer();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
+
 
             var app = builder.Build();
 


### PR DESCRIPTION
``## O que foi feito?
Para esta pull request, foi disponibilizado o padrão de documentação que os desenvolvedores podem seguir.

> [!WARNING]
> Na imagem abaixo, podemos observar a diferença na documentação entre os métodos GET e PUT, onde o padrão de documentação foi implementado no método GET.
![image](https://github.com/claudiokoori/back-gestao-de-clientes/assets/99252640/99db226a-9c5b-4681-886a-9538755ed4fc)

Agora veja conforme a documentação temos dois tipo de retorno, conforme foi desenvolvido.

1- Tipo 200 OK
![image](https://github.com/claudiokoori/back-gestao-de-clientes/assets/99252640/83f786ba-459a-4ff9-80f5-a0415a6932cb)


Tipo 404

![image](https://github.com/claudiokoori/back-gestao-de-clientes/assets/99252640/0059cf82-f819-4a80-a099-3bfe283a83c2)

Além disso foi modificado o método para que possamos detalhar o erro.
```csharp
 return NotFound(new
 {
     Instance = $"api/Clientes/{id}",
     status = 404,
     error = "Recurso não encontrado",
     message = "Ocorreu um erro ao tentar encontrar seu cliente.",
     Method = "Get",
 });
```

## Como configurar o método de retorno no swagger?
Para configurar o tipo de retorno na documentação, basta inserir o padrão conforme abaixo

Logo acima da endpoint.
```csharp
  /// <summary>
 /// Endpoint responsável por consultar o cliente pelo id.
 /// </summary>
 /// <param name="id">Código de identificação</param>
 /// <returns>Returna o resultado da operação com objeto preenchido.</returns>
 [ProducesResponseType(typeof(Cliente), StatusCodes.Status200OK)]
 [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
```

